### PR TITLE
Fix question format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Tom Clark <tom@octue.com>"]
 license = "MIT"

--- a/server/example/models.py
+++ b/server/example/models.py
@@ -149,6 +149,6 @@ class FooFightingQuestion(Question):
 
     def get_service_revision(self):
         """If no service revision is set, then simply use the default, otherwise use the specified version"""
-        if getattr(self, "service_revison", None) is None:
+        if getattr(self, "service_revision", None) is None:
             return get_default_service_revision("octue", "exa-foo-fighting-service")
         return self.service_revision

--- a/server/example/models.py
+++ b/server/example/models.py
@@ -140,7 +140,7 @@ class FooFightingQuestion(Question):
         return {
             "max_duration": int(self.foo_fighting_test.max_duration),
             "randomise_duration": int(self.foo_fighting_test.randomise_duration),
-            "test_id": int(self.foo_fighting_test.id),
+            "test_id": str(self.foo_fighting_test.id),
         }
 
     def get_input_manifest(self):


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#5](https://github.com/octue/exa/pull/5))

### Fixes
- Fix typo in attribute name
- Send test ID as a string to conform with child twine

<!--- END AUTOGENERATED NOTES --->